### PR TITLE
Use `ollama` library and display model details issue #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+publish_to_pypi.sh
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/ollachat/chatbot.py
+++ b/ollachat/chatbot.py
@@ -73,6 +73,25 @@ def assert_models_installed():
         st.stop()
 
 
+def select_model():
+    names = [model["name"] for model in OLLAMA_MODELS]
+    llm_name = st.sidebar.selectbox("Choose Agent", [""] + names)
+    if llm_name:
+
+        # llm details object
+        llm_details = [model for model in OLLAMA_MODELS if model["name"] == llm_name][0]
+
+        # convert size in llm_details from bytes to GB (human-friendly display)
+        if type(llm_details["size"]) != str:
+            llm_details["size"] = f"{round(llm_details['size'] / 1e9, 2)} GB"
+
+        # display llm details
+        with st.expander("LLM Details"):
+            st.write(llm_details)
+
+        return llm_name
+
+
 def save_conversation(llm_name, conversation_key):
 
     OUTPUT_DIR = "llm_conversations"
@@ -97,7 +116,7 @@ if __name__ == "__main__":
     page_config()
     
     st.sidebar.title("Ollama Chat 🦙")
-    llm_name = st.sidebar.selectbox("Choose Agent", [""] + OLLAMA_MODELS)
+    llm_name = select_model()
     
     assert_models_installed()
     

--- a/ollachat/list_ollama_models.py
+++ b/ollachat/list_ollama_models.py
@@ -1,86 +1,20 @@
-import re
-import subprocess
+from functools import lru_cache
+
+import ollama
 
 
-def _parse_names(data: str) -> list[str]:
-    """
-    Parses names from a multi-line string where each line contains a name and other details.
-
-    Parameters:
-    data (str): A multi-line string containing names and other details.
-
-    Returns:
-    list: A list containing the parsed names.
-    """
-    # Split the string into lines
-    lines = data.strip().split("\n")
-
-    # Skip the header line
-    lines = lines[1:]
-
-    # Regex pattern to match the name at the beginning of each line
-    pattern = r"^\S+"
-
-    # Extract names using regex
-    names = [
-        re.match(pattern, line).group(0) for line in lines if re.match(pattern, line)
-    ]
-
-    return names
-
-
-def _run_commandline(command: str) -> str:
-    """
-    Runs a commandline command and returns the output.
-
-    Parameters:
-    command (str): A string containing the command to be run.
-
-    Returns:
-    str: A string containing the output from the command.
-    """
-
-    command = command.split(" ")
-
-    # Run the command
-    result = subprocess.run(command, capture_output=True)
-
-    # Get the output
-    output = result.stdout.decode("utf-8")
-
-    return output
-
-
-def list_models() -> list[str]:
-    """
-    Lists all available OLLAMA models.
-
-    Parameters:
-    None
-
-    Returns:
-    None
-    """
-    # Run the command, and assert ollama is installed
-
-    try:
-        data = _run_commandline("ollama list")
-    except FileNotFoundError as e:
-        raise FileNotFoundError(
-            "Unable to find Ollama command. Please install OLLAMA first. See https://ollama.ai for more details.")
-
-    # Parse the names
-    names = _parse_names(data)
-
-    # assert len(names) < 0, "No models found. Please install OLLAMA first."
-
-
-    return sorted(names)
+@lru_cache(maxsize=2)
+def list_models():
+    models = ollama.list()["models"]
+    install_msg = "Please make sure Ollama is installed first. See https://ollama.ai for more details."
+    assert len(models) > 0, f"No models found. {install_msg}"
+    return models
 
 
 OLLAMA_MODELS = list_models()
 
+
 if __name__ == "__main__":
     # get list of names
-    names = list_models()
+    names = [model["name"] for model in OLLAMA_MODELS]
     print(names)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-llama_index==0.9.21
+llama_index==0.9.40
 streamlit==1.29.0
+ollama==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ HOME_URL = "https://github.com/iamaziz/st_ollama"
 
 setup(
     name="st_ollama",
-    version="0.1.3",
+    version="0.1.4",
     author="Aziz Alto",
     author_email="iamaziz.alto@gmail.com",
     description="A Streamlit chatbot app integrating Ollama LLMs",


### PR DESCRIPTION
**CHANGES**
- Use [Ollama package](https://github.com/ollama/ollama-python?tab=readme-ov-file#list) to list models
- pump llama_index to version to `0.9.40`
- Display the selected model details in `st.expander` e.g. 
<img width="1512" alt="image" src="https://github.com/iamaziz/st_ollama/assets/3298308/83673905-36f4-490f-b5ec-aa62d797667b">


Issue #1 
